### PR TITLE
Experimental attempt to use ja_serializer with phoenix 1.7.7 without using the fallback phoenix_view package

### DIFF
--- a/lib/example_17x_app_web.ex
+++ b/lib/example_17x_app_web.ex
@@ -38,7 +38,7 @@ defmodule Example17xAppWeb do
   def controller do
     quote do
       use Phoenix.Controller,
-        formats: [:html, :json],
+        formats: [:html, :json, :"json-api"],
         layouts: [html: Example17xAppWeb.Layouts]
 
       import Plug.Conn

--- a/lib/example_17x_app_web/views/thing_view.ex
+++ b/lib/example_17x_app_web/views/thing_view.ex
@@ -12,4 +12,8 @@ defmodule :"Elixir.Example17xAppWeb.ThingJSON-API" do
   def id(_data, _conn) do
     "singular"
   end
+
+  def type do
+    "things"
+  end
 end

--- a/lib/example_17x_app_web/views/thing_view.ex
+++ b/lib/example_17x_app_web/views/thing_view.ex
@@ -1,5 +1,10 @@
-defmodule Example17xAppWeb.ThingView do
-  use Example17xAppWeb, :view
+# Using an erlang atom as module name, otherwise dashes would not be allowed in the module name.
+# And if I don't do this then I get the error:
+#
+#   (ArgumentError) no "show" json-api template defined for
+#   :"Elixir.Example17xAppWeb.ThingJSON-API"  (the module does not exist)
+#
+defmodule :"Elixir.Example17xAppWeb.ThingJSON-API" do
   use JaSerializer.PhoenixView
 
   attributes([:volume_level])


### PR DESCRIPTION
This follows on from https://github.com/vt-elixir/ja_serializer/issues/346#issuecomment-1699277037 and is an attempt to explore the feasibility of using ja_serializer with phoenix 1.7.7 without using the fallback `phoenix_view` package.

It takes a few strange changes to make a basic ja_serializer scenario work (there may be more reasonable changes to could be made that I am unaware of - especially if some small supporting changes were made in ja_serializer). See inline comments below.

With these changes in place the simple test suite passes :partying_face: 

![image](https://github.com/theirishpenguin/example_17x_app/assets/39653/ea46ca3f-88c6-4fc7-976d-7ec475aa9180)
