### PR TITLE
 [Take 2 - Simplified Solution Changes] Experimental attempt to use ja_serializer with phoenix 1.7.7 without using the fallback phoenix_view package

### DIFF
--- a/lib/example_17x_app_web/controllers/thing_controller.ex
+++ b/lib/example_17x_app_web/controllers/thing_controller.ex
@@ -1,9 +1,22 @@
 defmodule Example17xAppWeb.ThingController do
   use Example17xAppWeb, :controller
 
+  # We use put_view() so we can control the name of the view rendered. It can be used as a plug or inline
+  # in the function (as shown below in the show() function). For more details on put_view() usage look under
+  # the render() documenation at https://hexdocs.pm/phoenix/0.10.0/Phoenix.Controller.html#render/3
+  #
+  plug :put_view, Example17xAppWeb.ThingView
+
   require Logger
 
   def show(conn, _) do
     render(conn, "show.json-api", data: %{volume_level: 33})
+
+    # Note: If you don't want to use the plug then you can use the following (can be useful for
+    # per-action based control)...
+    #
+    # conn
+    # |> put_view(Example17xAppWeb.ThingView)
+    # |> render("show.json-api", data: %{volume_level: 33})
   end
 end

--- a/lib/example_17x_app_web/views/thing_view.ex
+++ b/lib/example_17x_app_web/views/thing_view.ex
@@ -1,19 +1,9 @@
-# Using an erlang atom as module name, otherwise dashes would not be allowed in the module name.
-# And if I don't do this then I get the error:
-#
-#   (ArgumentError) no "show" json-api template defined for
-#   :"Elixir.Example17xAppWeb.ThingJSON-API"  (the module does not exist)
-#
-defmodule :"Elixir.Example17xAppWeb.ThingJSON-API" do
+defmodule Example17xAppWeb.ThingView do
   use JaSerializer.PhoenixView
 
   attributes([:volume_level])
 
   def id(_data, _conn) do
     "singular"
-  end
-
-  def type do
-    "things"
   end
 end


### PR DESCRIPTION
### WHAT?
This is a follow-on PR from https://github.com/theirishpenguin/example_17x_app/pull/3 that takes on **beerlington**'s advice to use `put_view()` to avoid hacky view module naming. It also means the type can be inferred from the module name by ja_serializer without any extra fuss.