### PR TITLE
 [Take 3 - Simplified Complete Solution] A way to use ja_serializer with a vanilla phoenix 1.7.X app - without using the fallback phoenix_view package

### DIFF
--- a/lib/example_17x_app_web.ex
+++ b/lib/example_17x_app_web.ex
@@ -38,7 +38,7 @@ defmodule Example17xAppWeb do
   def controller do
     quote do
       use Phoenix.Controller,
-        formats: [:html, :json],
+        formats: [:html, :json, :"json-api"],
         layouts: [html: Example17xAppWeb.Layouts]
 
       import Plug.Conn

--- a/lib/example_17x_app_web/controllers/thing_controller.ex
+++ b/lib/example_17x_app_web/controllers/thing_controller.ex
@@ -1,9 +1,22 @@
 defmodule Example17xAppWeb.ThingController do
   use Example17xAppWeb, :controller
 
+  # We use put_view() so we can control the name of the view rendered. It can be used as a plug or inline
+  # in the function (as shown below in the show() function). For more details on put_view() usage look under
+  # the render() documenation at https://hexdocs.pm/phoenix/0.10.0/Phoenix.Controller.html#render/3
+  #
+  plug :put_view, Example17xAppWeb.ThingView
+
   require Logger
 
   def show(conn, _) do
     render(conn, "show.json-api", data: %{volume_level: 33})
+
+    # Note: If you don't want to use the plug then you can use the following (can be useful for
+    # per-action based control)...
+    #
+    # conn
+    # |> put_view(Example17xAppWeb.ThingView)
+    # |> render("show.json-api", data: %{volume_level: 33})
   end
 end

--- a/lib/example_17x_app_web/views/thing_view.ex
+++ b/lib/example_17x_app_web/views/thing_view.ex
@@ -1,19 +1,9 @@
-# Using an erlang atom as module name, otherwise dashes would not be allowed in the module name.
-# And if I don't do this then I get the error:
-#
-#   (ArgumentError) no "show" json-api template defined for
-#   :"Elixir.Example17xAppWeb.ThingJSON-API"  (the module does not exist)
-#
-defmodule :"Elixir.Example17xAppWeb.ThingJSON-API" do
+defmodule Example17xAppWeb.ThingView do
   use JaSerializer.PhoenixView
 
   attributes([:volume_level])
 
   def id(_data, _conn) do
     "singular"
-  end
-
-  def type do
-    "things"
   end
 end

--- a/lib/example_17x_app_web/views/thing_view.ex
+++ b/lib/example_17x_app_web/views/thing_view.ex
@@ -12,4 +12,8 @@ defmodule :"Elixir.Example17xAppWeb.ThingJSON-API" do
   def id(_data, _conn) do
     "singular"
   end
+
+  def type do
+    "things"
+  end
 end

--- a/lib/example_17x_app_web/views/thing_view.ex
+++ b/lib/example_17x_app_web/views/thing_view.ex
@@ -1,5 +1,10 @@
-defmodule Example17xAppWeb.ThingView do
-  use Example17xAppWeb, :view
+# Using an erlang atom as module name, otherwise dashes would not be allowed in the module name.
+# And if I don't do this then I get the error:
+#
+#   (ArgumentError) no "show" json-api template defined for
+#   :"Elixir.Example17xAppWeb.ThingJSON-API"  (the module does not exist)
+#
+defmodule :"Elixir.Example17xAppWeb.ThingJSON-API" do
   use JaSerializer.PhoenixView
 
   attributes([:volume_level])


### PR DESCRIPTION
### Overview

This PR follows on from https://github.com/vt-elixir/ja_serializer/issues/346#issuecomment-1700836548 and is an attempt to document a reasonable way of using ja_serializer with phoenix 1.7.7 without using the fallback `phoenix_view` package.

With these changes in place the simple test suite passes :partying_face: 

![image](https://github.com/theirishpenguin/example_17x_app/assets/39653/ea46ca3f-88c6-4fc7-976d-7ec475aa9180)

###  Resources useful for understanding the move from phoenix 1.6.X to 1.7.X
* The full g/h issue at https://github.com/vt-elixir/ja_serializer/issues/346 (that lead to this PR)
* https://www.phoenixframework.org/blog/phoenix-1.7-final-released
* https://gist.github.com/chrismccord/00a6ea2a96bc57df0cce526bd20af8a7#pre-requirements
